### PR TITLE
Fixing Blueprint Error

### DIFF
--- a/blueprints/frost-demo/index.js
+++ b/blueprints/frost-demo/index.js
@@ -3,6 +3,14 @@ var path = require('path')
 module.exports = {
   description: 'Generates a frost demo route',
 
+  availableOptions: [
+    {
+      name: 'fullscreen',
+      type: Boolean,
+      default: false
+    }
+  ],
+
   locals: function (options) {
     if (!options.pod) {
       throw new Error('Must use with pods')

--- a/tests/dummy/files/fullscreen.md
+++ b/tests/dummy/files/fullscreen.md
@@ -11,7 +11,7 @@ ember generate demo my-awesome-fullscreen-demo --fullscreen --dummy --pod
     <p>Demo description goes here</p>
   </div>
   <div class="demo-showcase">
-    {{demo-editor path='non-fullscreen'}}
+    {{frost-demo-editor path='non-fullscreen'}}
     <div class="demo-view">
     Place you demo here
     </div>

--- a/tests/dummy/files/non-fullscreen.md
+++ b/tests/dummy/files/non-fullscreen.md
@@ -11,7 +11,7 @@ ember generate demo my-awesome-demo --dummy --pod
     <p>Demo description goes here</p>
   </div>
   <div class="demo-showcase">
-    {{demo-editor path='non-fullscreen'}}
+    {{frost-demo-editor path='non-fullscreen'}}
     <div class="demo-view">
     Place you demo here
     </div>


### PR DESCRIPTION
Running the `frost-demo` blueprint results in an error when specifying the `--fullscreen` option.  Somehow it didn't error out before until I started consuming this *addon*.

#PATCH#