### PR TITLE
Fix nested menus

### DIFF
--- a/addon/components/frost-demo-navbar/template.hbs
+++ b/addon/components/frost-demo-navbar/template.hbs
@@ -4,26 +4,33 @@
   {{/frost-button}}
 
   {{#each links as |link|}}
-    {{#link-to link.route}}
+    {{#if link.links}}
       {{#frost-button class='navigation menu hoverable-action' priority='' size=''}}
         <div class='icon-text'>
           <div class='text'>{{link.title}}</div>
           {{#if link.links}}{{frost-icon class='expand' icon='expand-collapse'}}{{/if}}
         </div>
-        {{#if link.links}}
-          {{#frost-popover position='bottom' as |close|}}
-           <div class='popup-menu'>
-             <ul>
-               {{#each link.links as |link|}}
-                {{#link-to link.route}}
-                   <li id='{{link.route}}'>{{link.title}}</li>
-                {{/link-to}}
-               {{/each}}
-             </ul>
-           </div>
-         {{/frost-popover}}
-        {{/if}}
+        {{#frost-popover position='bottom' as |close|}}
+         <div class='popup-menu'>
+           <ul>
+             {{#each link.links as |link|}}
+              {{#link-to link.route}}
+                 <li id='{{link.route}}'>{{link.title}}</li>
+              {{/link-to}}
+             {{/each}}
+           </ul>
+         </div>
+       {{/frost-popover}}
       {{/frost-button}}
-    {{/link-to}}
+    {{else}}
+      {{#link-to link.route}}
+        {{#frost-button class='navigation menu hoverable-action' priority='' size=''}}
+          <div class='icon-text'>
+            <div class='text'>{{link.title}}</div>
+            {{#if link.links}}{{frost-icon class='expand' icon='expand-collapse'}}{{/if}}
+          </div>
+        {{/frost-button}}
+      {{/link-to}}
+    {{/if}}
   {{/each}}
 </div>


### PR DESCRIPTION
#PATCH#

# CHANGELOG

* **Fixed** bug when specifying route and links for a given link. In this scenario the DOM would contain nested anchor tags which is invalid and would cause the nested links to redirect but then go back to the back of the parent link.