### PR TITLE
Update ivy-codemirror

### DIFF
--- a/addon/components/frost-demo-editor/template.hbs
+++ b/addon/components/frost-demo-editor/template.hbs
@@ -12,7 +12,7 @@
   {{frost-file-explorer fileTree=fileTree isCollapsed=collapseExplorer onFileClick='onFileClick'}}
   <div class='tab-gutter'></div>
   <div class="demo-code">
-    {{ivy-codemirror value=source lineNumbers=true mode=mode theme=codeTheme}}
+    {{ivy-codemirror value=source options=(hash lineNumbers=true mode=mode theme=codeTheme)}}
   </div>
 {{else}}
   <div class="demo-doc">

--- a/addon/components/frost-file-explorer/template.hbs
+++ b/addon/components/frost-file-explorer/template.hbs
@@ -1,6 +1,6 @@
 <div class='explorer-tab'>
   <span>
-    {{frost-icon icon='chevron'}}
+    {{frost-icon icon='chevron' pack='frost'}}
   </span>
 </div>
 {{#each fileTree as |node|}}

--- a/addon/components/frost-file-node/template.hbs
+++ b/addon/components/frost-file-node/template.hbs
@@ -1,6 +1,6 @@
 <div class='file-entry' {{action 'onFileClick'}}>
   <span class='indent' style={{indentStyle}} />
-  {{frost-icon icon='chevron'}}
+  {{frost-icon icon='chevron' pack='frost'}}
   <span class='file-icon' />
   <span class='file-name'>{{fileNode.name}}</span>
 </div>

--- a/blueprints/ember-frost-demo-components/index.js
+++ b/blueprints/ember-frost-demo-components/index.js
@@ -6,7 +6,7 @@ module.exports = {
       packages: [
         {name: 'ember-browserify', target: '^1.1.13'},
         {name: 'ember-frost-core', target: '^1.0.0'},
-        {name: 'ivy-codemirror', target: '^1.4.0'},
+        {name: 'ivy-codemirror', target: '^2.0.3'},
         {name: 'ember-cli-showdown', target: '^2.5.0'},
         {name: 'ember-prism', target: '>=0.0.7 <2.0.0'},
         {name: 'ember-frost-popover', target: '^4.0.0'}

--- a/bower.json
+++ b/bower.json
@@ -18,6 +18,7 @@
   },
   "resolutions": {
     "ember": "~2.8.0",
-    "jquery": "2.2.4"
+    "jquery": "2.2.4",
+    "codemirror": "^5.17.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "ember-truth-helpers": "1.2.0",
     "eslint": "^3.1.1",
     "eslint-config-frost-standard": "^4.0.0",
-    "ivy-codemirror": "^1.4.0",
+    "ivy-codemirror": "^2.0.3",
     "loader.js": "^4.0.1",
     "lodash-es": "4.14.1",
     "remark-cli": "^2.1.0",


### PR DESCRIPTION
I noticed that packages downstream have already upgraded `ivy-codemirror` to the latest which resulted in themes and configurations not being applied. This update requires wrapping up those settings in a hash before being sent to `ivy-codemirror`.

#MAJOR# since it updates to a major release of `ivy-codemirror`.